### PR TITLE
Função enqueue() não inseria na 1a posição

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -19,7 +19,7 @@ int isFull(struct Fila *f){
 }
 int enqueue(struct Fila *f, int elemento){
 	if(isFull(f)) return 0;
-	f->elementos[(f->final + 1) % f->tamanho] = elemento;
+	f->elementos[f->final % f->tamanho] = elemento;
 	f->final = (f->final + 1) % f->tamanho;
 	return 1;
 }


### PR DESCRIPTION
A função enqueue() sempre inseria na posição "final + 1", então ao inserir o primeiro elemento ele acabava sendo inserido na posiçao 1 em vez da posição 0.